### PR TITLE
Release 1.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-core-shared-libs",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-core-shared-libs",
-            "version": "1.11.1",
+            "version": "1.11.2",
             "license": "GPL-2.0"
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-core-shared-libs",
-    "version": "1.11.1",
+    "version": "1.11.2",
     "description": "TAO Frontent Core Shared Libraries",
     "files": [
         "lib"


### PR DESCRIPTION
## Summary
- bump `@oat-sa/tao-core-shared-libs` version from `1.11.1` to `1.11.2`
- update the root lockfile to keep published package metadata in sync
- prepare the repository for the 1.11.2 npm release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.11.2 (patch release)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->